### PR TITLE
Remove Go wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Wiki should be detail, up to date and well structured. It should be easy to find
 - [hyperledger/cacti](https://github.com/hyperledger/cacti/wiki)
 - [facebook/react-native](https://github.com/facebook/react-native/wiki)
 - [FortAwesome/Font-Awesome](https://github.com/FortAwesome/Font-Awesome/wiki)
-- [golang/go](https://github.com/golang/go/wiki)
 - [uber/NullAway](https://github.com/uber/NullAway/wiki)
 - [internetarchive/openlibrary](https://github.com/internetarchive/openlibrary/wiki)
 


### PR DESCRIPTION
The Go wiki has been moved off GitHub. Removed so the list stays up to date.