### PR TITLE
Add SO question

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Wiki should be detail, up to date and well structured. It should be easy to find
 - [How to make "spoiler" text in GitHub Wiki pages](https://stackoverflow.com/questions/32814161/how-to-make-spoiler-text-in-github-wiki-pages)
 - [How to integrate a GitHub wiki into the main project](https://stackoverflow.com/questions/6941688/how-to-integrate-a-github-wiki-into-the-main-project)
 - [How can I make a pull request for a Wiki page on GitHub?](https://stackoverflow.com/questions/10642928/how-can-i-make-a-pull-request-for-a-wiki-page-on-github)
+- [How to remove GitHub's Wiki default sidebar?](https://stackoverflow.com/questions/23635414/how-to-remove-githubs-wiki-default-sidebar)
 
 ## Contributing
 Contributions are very welcome! Please read the [contribution guideline](contributing.md) first.


### PR DESCRIPTION
https://stackoverflow.com/questions/23635414/how-to-remove-githubs-wiki-default-sidebar

How to remove Github's Wiki default sidebar